### PR TITLE
Added support for FRITZ!OS 7

### DIFF
--- a/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/PowerMeter.java
+++ b/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/PowerMeter.java
@@ -20,7 +20,7 @@ package com.github.kaklakariada.fritzbox.model.homeautomation;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
-@Root(name = "powermeter")
+@Root(name = "powermeter", strict = false)
 public class PowerMeter {
 
     @Element(name = "power", required = false)


### PR DESCRIPTION
With FRITZ!OS 7 the xml for PowerMeter got a new element "voltage". To be safe for more new elements in the future I added `strict = false` for the `@Root` annotation.