### PR TITLE
IDEA-114 added homeautomation group support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.0] - unreleased
 
+### Added
+
+* [#19](https://github.com/kaklakariada/fritzbox-java-api/pull/19) Support for device groups
+
 ## [1.3.1] - 2021-02-26
 
 * No changes, update deployment to Maven Central

--- a/build.gradle
+++ b/build.gradle
@@ -48,11 +48,13 @@ dependencies {
     
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.mockito:mockito-core:3.5.15'
+    testImplementation 'org.assertj:assertj-core:3.19.0'
 }
 
 license {
     header = file('gradle/license-header.txt')
     exclude('**/deviceList*Payload.xml')
+    exclude('devicelist6840.xml')
 }
 
 jacocoTestReport {

--- a/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/Device.java
+++ b/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/Device.java
@@ -41,7 +41,7 @@ public class Device {
 
     @Element(name = "present")
     private String present;
-    @Element(name = "txbusy")
+    @Element(name = "txbusy", required = false)
     private String txbusy;
     @Element(name = "name")
     private String name;

--- a/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/DeviceList.java
+++ b/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/DeviceList.java
@@ -34,7 +34,11 @@ public class DeviceList {
     @ElementList(name = "device", type = Device.class, inline = true)
     private List<Device> devices;
 
-    @Attribute(name = "fwversion")
+    @ElementList(name = "group", type = Group.class, inline = true, required = false)
+    private List<Group> groups;
+
+
+    @Attribute(name = "fwversion", required = false, empty = "n/a")
     private String firmwareVersion;
 
     public String getApiVersion() {
@@ -43,6 +47,10 @@ public class DeviceList {
 
     public List<Device> getDevices() {
         return devices;
+    }
+
+    public List<Group> getGroups() {
+        return groups;
     }
 
     public Device getDeviceByIdentifier(String identifier) {
@@ -67,6 +75,13 @@ public class DeviceList {
 
     private static String normalizeIdentifier(String identifier) {
         return identifier.replace(" ", "");
+    }
+
+    public Group getGroupById(String id) {
+        return groups.stream()
+                .filter(group -> group.getId().equals(id))
+                .findFirst()
+                .orElse(null);
     }
 
     @Override

--- a/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/Group.java
+++ b/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/Group.java
@@ -1,0 +1,93 @@
+/**
+ * A Java API for managing FritzBox HomeAutomation
+ * Copyright (C) 2017 Christoph Pirkl <christoph at users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.kaklakariada.fritzbox.model.homeautomation;
+
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+
+@Root(name = "group")
+public class Group {
+
+    @Attribute(name = "identifier")
+    private String identifier;
+    @Attribute(name = "id")
+    private String id;
+    @Attribute(name = "functionbitmask")
+    private int functionBitmask;
+    @Attribute(name = "fwversion")
+    private String firmwareVersion;
+    @Attribute(name = "manufacturer")
+    private String manufacturer;
+    @Attribute(name = "productname")
+    private String productName;
+    @Element(name = "present")
+    private String present;
+    @Element(name = "name")
+    private String name;
+    @Element(name = "switch", required = false)
+    private SwitchState switchState;
+    @Element(name = "powermeter", required = false)
+    private PowerMeter powerMeter;
+    @Element(name = "groupinfo", required = false)
+    private GroupInfo groupInfo;
+
+    public String getId() {
+        return id;
+    }
+
+    public int getFunctionBitmask() {
+        return functionBitmask;
+    }
+
+    public String getFirmwareVersion() {
+        return firmwareVersion;
+    }
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public String getPresent() {
+        return present;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public SwitchState getSwitchState() {
+        return switchState;
+    }
+
+    public PowerMeter getPowerMeter() {
+        return powerMeter;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public GroupInfo getGroupInfo() {
+        return groupInfo;
+    }
+}

--- a/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/GroupInfo.java
+++ b/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/GroupInfo.java
@@ -17,38 +17,33 @@
  */
 package com.github.kaklakariada.fritzbox.model.homeautomation;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
-@Root(name = "powermeter", strict = false)
-public class PowerMeter {
+@Root(name="groupinfo")
+public class GroupInfo {
 
-    @Element(name = "voltage", required = false)
-    private int voltageMilliVolt;
-    @Element(name = "power", required = false)
-    private int powerMilliWatt;
-    @Element(name = "energy", required = false)
-    private int energyWattHours;
+    @Element(name="masterdeviceid")
+    private String masterDeviceId;
 
-    public float getVoltageVolt() {
-        return voltageMilliVolt / 1000F;
+    /**
+     * Comma seperated list of devices identfied by their id.
+     */
+    @Element(name="members")
+    private String members;
+
+    public String getMasterDeviceId() {
+        return masterDeviceId;
     }
 
-    public float getPowerWatt() {
-        return powerMilliWatt / 1000F;
+    public String getMembers() {
+        return members;
     }
 
-    public int getEnergyWattHours() {
-        return energyWattHours;
-    }
-
-    public int getPowerMilliWatt() {
-        return powerMilliWatt;
-    }
-
-    @Override
-    public String toString() {
-        return "PowerMeter [voltage=" + getVoltageVolt() + ", energyWattHours=" + energyWattHours + ", powerWatt="
-                + getPowerWatt() + "]";
+    public List<String> getMemberList() {
+        return Arrays.asList(this.members.split(","));
     }
 }

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/DeviceListAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/DeviceListAssert.java
@@ -26,7 +26,7 @@ public class DeviceListAssert extends AbstractObjectAssert<DeviceListAssert, Dev
 
     private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
 
-    public DeviceListAssert(DeviceList actual) {
+    DeviceListAssert(DeviceList actual) {
         super(actual, DeviceListAssert.class);
     }
 

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/DeviceListAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/DeviceListAssert.java
@@ -1,0 +1,40 @@
+/**
+ * A Java API for managing FritzBox HomeAutomation
+ * Copyright (C) 2017 Christoph Pirkl <christoph at users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.kaklakariada.fritzbox.assertions;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+
+import com.github.kaklakariada.fritzbox.model.homeautomation.DeviceList;
+
+public class DeviceListAssert extends AbstractObjectAssert<DeviceListAssert, DeviceList> {
+
+    private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
+
+    public DeviceListAssert(DeviceList actual) {
+        super(actual, DeviceListAssert.class);
+    }
+
+    public DeviceListAssert hasGroupsSize(int expected) {
+        int actualGroupsSize = actual.getGroups().size();
+        Assertions.assertThat(actualGroupsSize)
+                .overridingErrorMessage(ERROR_MESSAGE, "groupSize", expected, actualGroupsSize, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+}

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/GroupAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/GroupAssert.java
@@ -27,7 +27,7 @@ public class GroupAssert extends AbstractObjectAssert<GroupAssert, Group> {
 
     private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
 
-    public GroupAssert(Group actual) {
+    GroupAssert(Group actual) {
         super(actual, GroupAssert.class);
     }
 

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/GroupAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/GroupAssert.java
@@ -1,0 +1,49 @@
+/**
+ * A Java API for managing FritzBox HomeAutomation
+ * Copyright (C) 2017 Christoph Pirkl <christoph at users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.kaklakariada.fritzbox.assertions;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+
+import com.github.kaklakariada.fritzbox.model.homeautomation.Group;
+
+
+public class GroupAssert extends AbstractObjectAssert<GroupAssert, Group> {
+
+    private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
+
+    public GroupAssert(Group actual) {
+        super(actual, GroupAssert.class);
+    }
+
+    public GroupAssert hasName(String expected) {
+        String actual = this.actual.getName();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "name", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+
+    public GroupAssert hasPresent(String expected) {
+        String actual = this.actual.getPresent();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "present", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+}

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/GroupInfoAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/GroupInfoAssert.java
@@ -30,7 +30,7 @@ public class GroupInfoAssert extends AbstractObjectAssert<GroupInfoAssert, Group
 
     private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
 
-    public GroupInfoAssert(GroupInfo actual) {
+    GroupInfoAssert(GroupInfo actual) {
         super(actual, GroupInfoAssert.class);
     }
 

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/GroupInfoAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/GroupInfoAssert.java
@@ -1,0 +1,52 @@
+/**
+ * A Java API for managing FritzBox HomeAutomation
+ * Copyright (C) 2017 Christoph Pirkl <christoph at users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.kaklakariada.fritzbox.assertions;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+
+import com.github.kaklakariada.fritzbox.model.homeautomation.GroupInfo;
+
+
+public class GroupInfoAssert extends AbstractObjectAssert<GroupInfoAssert, GroupInfo> {
+
+    private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
+
+    public GroupInfoAssert(GroupInfo actual) {
+        super(actual, GroupInfoAssert.class);
+    }
+
+    public GroupInfoAssert hasMasterDeviceId(String expected) {
+        String actual = this.actual.getMasterDeviceId();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "masterDeviceId", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+
+    public GroupInfoAssert containsAllMembers(String ... expected) {
+        List<String> actual = this.actual.getMemberList();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "memberList", expected, actual, descriptionText())
+                .containsExactlyInAnyOrderElementsOf(Arrays.asList(expected));
+        return this;
+    }
+}

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/HomeAutomationAssertions.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/HomeAutomationAssertions.java
@@ -1,0 +1,52 @@
+/**
+ * A Java API for managing FritzBox HomeAutomation
+ * Copyright (C) 2017 Christoph Pirkl <christoph at users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.kaklakariada.fritzbox.assertions;
+
+import com.github.kaklakariada.fritzbox.model.homeautomation.DeviceList;
+import com.github.kaklakariada.fritzbox.model.homeautomation.Group;
+import com.github.kaklakariada.fritzbox.model.homeautomation.GroupInfo;
+import com.github.kaklakariada.fritzbox.model.homeautomation.PowerMeter;
+import com.github.kaklakariada.fritzbox.model.homeautomation.SwitchState;
+
+public class HomeAutomationAssertions {
+
+    private HomeAutomationAssertions() {
+
+    }
+
+    public static DeviceListAssert assertThat(DeviceList deviceList) {
+        return new DeviceListAssert(deviceList);
+    }
+
+    public static GroupAssert assertThat(Group group) {
+        return new GroupAssert(group);
+    }
+
+    public static SwitchStateAssert assertThat(SwitchState switchState) {
+        return new SwitchStateAssert(switchState);
+    }
+
+    public static PowerMeterAssert assertThat(PowerMeter powerMeter) {
+        return new PowerMeterAssert(powerMeter);
+    }
+
+    public static GroupInfoAssert assertThat(GroupInfo groupInfo) {
+        return new GroupInfoAssert(groupInfo);
+    }
+
+}

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/PowerMeterAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/PowerMeterAssert.java
@@ -27,7 +27,7 @@ public class PowerMeterAssert extends AbstractObjectAssert<PowerMeterAssert, Pow
 
     private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
 
-    public PowerMeterAssert(PowerMeter actual) {
+    PowerMeterAssert(PowerMeter actual) {
         super(actual, PowerMeterAssert.class);
     }
 

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/PowerMeterAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/PowerMeterAssert.java
@@ -1,0 +1,49 @@
+/**
+ * A Java API for managing FritzBox HomeAutomation
+ * Copyright (C) 2017 Christoph Pirkl <christoph at users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.kaklakariada.fritzbox.assertions;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+
+import com.github.kaklakariada.fritzbox.model.homeautomation.PowerMeter;
+
+
+public class PowerMeterAssert extends AbstractObjectAssert<PowerMeterAssert, PowerMeter> {
+
+    private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
+
+    public PowerMeterAssert(PowerMeter actual) {
+        super(actual, PowerMeterAssert.class);
+    }
+
+    public PowerMeterAssert hasPowerMilliWatt(int expected) {
+        int actual = this.actual.getPowerMilliWatt();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "powerMilliWatt", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+
+    public PowerMeterAssert hasEnergyWattHours(int expected) {
+        int actual = this.actual.getEnergyWattHours();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "energyWattHours", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+}

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/SwitchStateAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/SwitchStateAssert.java
@@ -1,0 +1,65 @@
+/**
+ * A Java API for managing FritzBox HomeAutomation
+ * Copyright (C) 2017 Christoph Pirkl <christoph at users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.kaklakariada.fritzbox.assertions;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+
+import com.github.kaklakariada.fritzbox.model.homeautomation.SwitchState;
+
+
+public class SwitchStateAssert extends AbstractObjectAssert<SwitchStateAssert, SwitchState> {
+
+    private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
+
+    public SwitchStateAssert(SwitchState actual) {
+        super(actual, SwitchStateAssert.class);
+    }
+
+    public SwitchStateAssert isOn(boolean expected) {
+        boolean actual = this.actual.isOn();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "on", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+
+    public SwitchStateAssert hasMode(SwitchState.SwitchMode expected) {
+        SwitchState.SwitchMode actual = this.actual.getMode();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "mode", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+
+    public SwitchStateAssert isLocked(boolean expected) {
+        boolean actual = this.actual.isLocked();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "locked", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+
+    public SwitchStateAssert isDeviceLocked(boolean expected) {
+        boolean actual = this.actual.isDeviceLocked();
+        Assertions.assertThat(actual)
+                .overridingErrorMessage(ERROR_MESSAGE, "deviceLocked", expected, actual, descriptionText())
+                .isEqualTo(expected);
+        return this;
+    }
+}

--- a/src/test/java/com/github/kaklakariada/fritzbox/assertions/SwitchStateAssert.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/assertions/SwitchStateAssert.java
@@ -27,7 +27,7 @@ public class SwitchStateAssert extends AbstractObjectAssert<SwitchStateAssert, S
 
     private static final String ERROR_MESSAGE = "Expected %s to be <%s> but was <%s> (%s)";
 
-    public SwitchStateAssert(SwitchState actual) {
+    SwitchStateAssert(SwitchState actual) {
         super(actual, SwitchStateAssert.class);
     }
 

--- a/src/test/resources/devicelist6840.xml
+++ b/src/test/resources/devicelist6840.xml
@@ -1,0 +1,87 @@
+<devicelist version="1">
+    <device identifier="08761 0485961" id="16" functionbitmask="2944" fwversion="04.09" manufacturer="AVM"
+            productname="FRITZ!DECT 200">
+        <present>1</present>
+        <name>Photovoltaik</name>
+        <switch>
+            <state>1</state>
+            <mode>manuell</mode>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+        </switch>
+        <powermeter>
+            <power>38480</power>
+            <energy>875112</energy>
+        </powermeter>
+        <temperature>
+            <celsius>200</celsius>
+            <offset>0</offset>
+        </temperature>
+    </device>
+    <group identifier="88:88:A6-900" id="900" functionbitmask="6784" fwversion="1.0" manufacturer="AVM" productname="">
+        <present>1</present>
+        <name>PV</name>
+        <switch>
+            <state>1</state>
+            <mode>manuell</mode>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+        </switch>
+        <powermeter>
+            <power>38480</power>
+            <energy>875112</energy>
+        </powermeter>
+        <groupinfo>
+            <masterdeviceid>0</masterdeviceid>
+            <members>16</members>
+        </groupinfo>
+    </group>
+    <device identifier="11630 0089206" id="17" functionbitmask="2944" fwversion="04.16" manufacturer="AVM"
+            productname="FRITZ!DECT 200">
+        <present>1</present>
+        <name>Schreibtischleuchte</name>
+        <switch>
+            <state>1</state>
+            <mode>manuell</mode>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+        </switch>
+        <powermeter>
+            <power>5720</power>
+            <energy>936161</energy>
+        </powermeter>
+        <temperature>
+            <celsius>240</celsius>
+            <offset>0</offset>
+        </temperature>
+    </device>
+    <group identifier="88:88:A6-901" id="901" functionbitmask="6816" fwversion="1.0" manufacturer="AVM" productname="">
+        <present>1</present>
+        <name>Yppsenwautschi</name>
+        <switch>
+            <state>1</state>
+            <mode>manuell</mode>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+        </switch>
+        <powermeter>
+            <power>5720</power>
+            <energy>936161</energy>
+        </powermeter>
+        <groupinfo>
+            <masterdeviceid>0</masterdeviceid>
+            <members>17,18</members>
+        </groupinfo>
+    </group>
+    <device identifier="13096 0036147" id="18" functionbitmask="544" fwversion="04.90" manufacturer="AVM"
+            productname="">
+        <present>1</present>
+        <name>Schalter</name>
+        <switch>
+            <state>0</state>
+            <mode>manuell</mode>
+            <lock>0</lock>
+            <devicelock>0</devicelock>
+        </switch>
+    </device>
+</devicelist>


### PR DESCRIPTION
added assertJ core as test support
added homeautomation models Group and GroupInfo
marked txBusy and fwVersion as non required, as those attributes are not supported by older Fritz!OS versions.
added PowerMeter.getPowerMilliWatt to provide the original metric values.
added Assertion classes for the model objects
added a test xml stream to tst older Fritz!Boxes