### PR TITLE
Add support of empty device lists fixes #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#29](https://github.com/kaklakariada/fritzbox-java-api/issues/29) Add support for login via Pbkdf2 challenge-response (propsed by [@linnex81](https://github.com/linnex81))
 
+### Fixed
+
+* [#37](https://github.com/kaklakariada/fritzbox-java-api/issues/37) Support empty device lists
+
 ### Refactoring
 
 * [#50](https://github.com/kaklakariada/fritzbox-java-api/pull/50) Migrate to Junit 5

--- a/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/DeviceList.java
+++ b/src/main/java/com/github/kaklakariada/fritzbox/model/homeautomation/DeviceList.java
@@ -19,6 +19,7 @@ package com.github.kaklakariada.fritzbox.model.homeautomation;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.simpleframework.xml.Attribute;
@@ -31,8 +32,8 @@ public class DeviceList {
     @Attribute(name = "version")
     private String apiVersion;
 
-    @ElementList(name = "device", type = Device.class, inline = true)
-    private List<Device> devices;
+    @ElementList(name = "device", type = Device.class, inline = true, required = false)
+    private List<Device> devices = new ArrayList<>();
 
     @ElementList(name = "group", type = Group.class, inline = true, required = false)
     private List<Group> groups;

--- a/src/test/java/com/github/kaklakariada/fritzbox/mapping/DeserializerTest.java
+++ b/src/test/java/com/github/kaklakariada/fritzbox/mapping/DeserializerTest.java
@@ -91,6 +91,12 @@ class DeserializerTest {
     }
 
     @Test
+    void parseDeviceListEmpty() throws IOException {
+        final DeviceList deviceList = parseDeviceList(Paths.get("src/test/resources/FritzOS29/deviceListEmpty.xml"));
+        assertThat(deviceList.getDevices()).hasSize(0);
+    }
+
+    @Test
     void parseDeviceList() throws IOException {
         final DeviceList deviceList = parseDeviceList(Paths.get("src/test/resources/deviceList.xml"));
         assertThat(deviceList.getDevices()).hasSize(16);

--- a/src/test/resources/FritzOS29/deviceListEmpty.xml
+++ b/src/test/resources/FritzOS29/deviceListEmpty.xml
@@ -1,0 +1,1 @@
+<devicelist version="1" fwversion="7.29"></devicelist>


### PR DESCRIPTION
This pull request adds empty device list support because this is an valid and expected state if no smart home device is connected.